### PR TITLE
Add E2E tests for Battlesnake list page

### DIFF
--- a/e2e/tests/battlesnake-list.spec.ts
+++ b/e2e/tests/battlesnake-list.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../fixtures/test';
+
+test.describe('Battlesnake List', () => {
+  test('displays empty state when user has no battlesnakes', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/battlesnakes');
+
+    await expect(authenticatedPage.getByRole('heading', { name: 'Your Battlesnakes' })).toBeVisible();
+    await expect(authenticatedPage.getByText("You don't have any battlesnakes yet.")).toBeVisible();
+  });
+
+  test('displays battlesnakes after creation', async ({ authenticatedPage }) => {
+    const uniqueName = `List Test Snake ${Date.now()}`;
+
+    // First create a battlesnake
+    await authenticatedPage.goto('/battlesnakes/new');
+    await authenticatedPage.getByLabel('Name').fill(uniqueName);
+    await authenticatedPage.getByLabel('URL').fill('https://example.com/snake');
+    await authenticatedPage.getByLabel('Visibility').selectOption('public');
+    await authenticatedPage.getByRole('button', { name: 'Create Battlesnake' }).click();
+
+    // Should be on the list page
+    await expect(authenticatedPage).toHaveURL('/battlesnakes');
+
+    // Battlesnake should appear in the table
+    await expect(authenticatedPage.getByText(uniqueName)).toBeVisible();
+    await expect(authenticatedPage.getByText('https://example.com/snake')).toBeVisible();
+    await expect(authenticatedPage.getByText('Public')).toBeVisible();
+  });
+
+  test('shows correct visibility badges', async ({ authenticatedPage }) => {
+    const publicName = `Public Snake ${Date.now()}`;
+    const privateName = `Private Snake ${Date.now()}`;
+
+    // Create a public snake
+    await authenticatedPage.goto('/battlesnakes/new');
+    await authenticatedPage.getByLabel('Name').fill(publicName);
+    await authenticatedPage.getByLabel('URL').fill('https://example.com/public');
+    await authenticatedPage.getByLabel('Visibility').selectOption('public');
+    await authenticatedPage.getByRole('button', { name: 'Create Battlesnake' }).click();
+    await expect(authenticatedPage).toHaveURL('/battlesnakes');
+
+    // Create a private snake
+    await authenticatedPage.goto('/battlesnakes/new');
+    await authenticatedPage.getByLabel('Name').fill(privateName);
+    await authenticatedPage.getByLabel('URL').fill('https://example.com/private');
+    await authenticatedPage.getByLabel('Visibility').selectOption('private');
+    await authenticatedPage.getByRole('button', { name: 'Create Battlesnake' }).click();
+    await expect(authenticatedPage).toHaveURL('/battlesnakes');
+
+    // Both should be visible with correct badges
+    const publicRow = authenticatedPage.locator('tr', { hasText: publicName });
+    const privateRow = authenticatedPage.locator('tr', { hasText: privateName });
+
+    // Check for badge elements specifically (they have the badge class)
+    await expect(publicRow.locator('.badge', { hasText: 'Public' })).toBeVisible();
+    await expect(privateRow.locator('.badge', { hasText: 'Private' })).toBeVisible();
+  });
+
+  test('shows edit and delete buttons for each snake', async ({ authenticatedPage }) => {
+    const uniqueName = `Actions Test Snake ${Date.now()}`;
+
+    // Create a snake
+    await authenticatedPage.goto('/battlesnakes/new');
+    await authenticatedPage.getByLabel('Name').fill(uniqueName);
+    await authenticatedPage.getByLabel('URL').fill('https://example.com/actions');
+    await authenticatedPage.getByLabel('Visibility').selectOption('public');
+    await authenticatedPage.getByRole('button', { name: 'Create Battlesnake' }).click();
+
+    // Find the row with our snake
+    const snakeRow = authenticatedPage.locator('tr', { hasText: uniqueName });
+
+    // Should have Edit and Delete buttons
+    await expect(snakeRow.getByRole('link', { name: 'Edit' })).toBeVisible();
+    await expect(snakeRow.getByRole('button', { name: 'Delete' })).toBeVisible();
+  });
+
+  test('has Add New Battlesnake button', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/battlesnakes');
+
+    const addButton = authenticatedPage.getByRole('link', { name: 'Add New Battlesnake' });
+    await expect(addButton).toBeVisible();
+    await expect(addButton).toHaveAttribute('href', '/battlesnakes/new');
+  });
+
+  test('list page requires authentication', async ({ page }) => {
+    const response = await page.goto('/battlesnakes');
+    expect(response?.status()).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 6 E2E tests for the Battlesnake list page
- Tests cover empty state, display after creation, visibility badges, action buttons, navigation, and authentication requirements

## Test Coverage
- `displays empty state when user has no battlesnakes`
- `displays battlesnakes after creation`
- `shows correct visibility badges`
- `shows edit and delete buttons for each snake`
- `has Add New Battlesnake button`
- `list page requires authentication`

## Stack
1/6 in E2E testing stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)