### PR TITLE
Fix flash messages by removing double Flash extraction

### DIFF
--- a/e2e/tests/battlesnake-create.spec.ts
+++ b/e2e/tests/battlesnake-create.spec.ts
@@ -40,6 +40,23 @@ test.describe('Create Battlesnake', () => {
     await expect(authenticatedPage.getByText(uniqueName)).toBeVisible();
   });
 
+  test('shows success flash message after creating battlesnake', async ({ authenticatedPage }) => {
+    const uniqueName = `Flash Test Snake ${Date.now()}`;
+
+    await authenticatedPage.goto('/battlesnakes/new');
+    await authenticatedPage.getByLabel('Name').fill(uniqueName);
+    await authenticatedPage.getByLabel('URL').fill('https://example.com/flash-test');
+    await authenticatedPage.getByLabel('Visibility').selectOption('public');
+    await authenticatedPage.getByRole('button', { name: 'Create Battlesnake' }).click();
+
+    await expect(authenticatedPage).toHaveURL('/battlesnakes');
+
+    // Should see success flash message (check for the alert container with success styling)
+    const successAlert = authenticatedPage.locator('.alert-success');
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toContainText('Battlesnake created successfully!');
+  });
+
   test('new form requires authentication', async ({ page }) => {
     // Without authentication, should get 401
     const response = await page.goto('/battlesnakes/new');

--- a/server/src/components/page_factory.rs
+++ b/server/src/components/page_factory.rs
@@ -11,7 +11,8 @@ use crate::{
 /// This extractor is responsible for creating Page instances with all necessary components
 /// like flash messages. It extracts FlashMessage and uses it when creating pages.
 pub struct PageFactory {
-    flash: Flash,
+    /// The flash message extracted from the session (already cleared from DB)
+    pub flash: Flash,
 }
 
 impl PageFactory {


### PR DESCRIPTION
## Summary
Fix flash messages not appearing after actions like creating a battlesnake.

## Problem
Handlers using both `PageFactory` and `Flash` extractors caused flash messages to be extracted twice:
1. `PageFactory` extracts `Flash` internally and clears it from the database
2. The separate `Flash` parameter extracted it again - but it was already cleared

This resulted in flash messages always being `None` when the handler tried to display them.

## Solution
- Made `PageFactory.flash` public to allow handlers to access the already-extracted flash
- Updated battlesnake handlers to use `page_factory.flash.clone()` instead of a separate `Flash` extractor
- Added E2E test verifying success flash appears after creating a battlesnake

## Test Coverage
- `shows success flash message after creating battlesnake`

## Stack
6/6 in E2E testing stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)