### PR TITLE
Upgrade eyes-subscriber to use batch HTTP transport and Fix Deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,6 @@ jobs:
 
       - name: Deploy to Cloud Run
         run: |
-          gcloud run services update bs-beta \
+          gcloud run services update ${{ secrets.GCP_CLOUD_RUN_SERVICE }} \
             --region ${{ secrets.GCP_REGION }} \
             --image ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_ARTIFACT_REGISTRY }}/arena:${{ github.sha }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "eyes-subscriber"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6530a8acc931dda83321cd17dffc15b652a794ff9565563f9040dc93971ce639"
+checksum = "cee297576f5c72dfda24c1499398146ecc328fe73996d46b964ea9df07669dfd"
 dependencies = [
  "async-trait",
  "chrono",


### PR DESCRIPTION
Patches eyes-subscriber to use the latest version from the eyes git repo
which includes batch HTTP transport support. This reduces network overhead
for high-volume tracing by batching events before sending.

To enable batch transport, set EYES_TRANSPORT=batching in deployment config, which was done in the infra repo
